### PR TITLE
fix: support any value type in sendTemplateMail

### DIFF
--- a/packages/gatsby-jaen-mailpress/src/index.ts
+++ b/packages/gatsby-jaen-mailpress/src/index.ts
@@ -5,7 +5,7 @@ export const sendTemplateMail = async (
   id: string,
   options?: {
     envelope?: Partial<EnvelopeInput>
-    values?: Record<string, string>
+    values?: Record<string, any>
   }
 ) => {
   try {


### PR DESCRIPTION
This pull request includes a small but important change to the `sendTemplateMail` function in the `packages/gatsby-jaen-mailpress/src/index.ts` file. The change modifies the type of the `values` property in the `options` parameter from `Record<string, string>` to `Record<string, any>`.

* [`packages/gatsby-jaen-mailpress/src/index.ts`](diffhunk://#diff-59739bd9e1586d7bd1ae752a8eefbc52496a909283cd4fdb900714b16cb2055aL8-R8): Changed the type of `values` from `Record<string, string>` to `Record<string, any>` to allow for more flexibility in the types of values that can be passed.