### PR TITLE
feat: enable customizable Sentry feedback integration

### DIFF
--- a/packages/gatsby-plugin-jaen/src/gatsby/on-client-entry.ts
+++ b/packages/gatsby-plugin-jaen/src/gatsby/on-client-entry.ts
@@ -35,17 +35,18 @@ export const onClientEntry: GatsbyBrowser['onClientEntry'] = async (
   Sentry.addIntegration(Sentry.browserProfilingIntegration())
   Sentry.addIntegration(Sentry.replayIntegration())
 
-  // Temporary disable Sentry feedback integration
-  // A lot of websites build using Jaen are targeted at non-engish speaking
-  // users and the feedback form is in english. This can be confusing for users.
-  // Sentry.addIntegration(
-  //   Sentry.feedbackIntegration({
-  //     colorScheme: 'light',
-  //     showBranding: false,
-  //     formTitle: 'Give Feedback',
-  //     buttonLabel: 'Feedback',
-  //     submitButtonLabel: 'Send Feedback',
-  //     messagePlaceholder: 'Report an issue or share your ideas.'
-  //   })
-  // )
+  if (pluginOptions.feedbackIntegration) {
+    Sentry.addIntegration(
+      Sentry.feedbackIntegration({
+        colorScheme: 'light',
+        showBranding: false,
+        formTitle: 'Give Feedback',
+        buttonLabel: 'Feedback',
+        submitButtonLabel: 'Send Feedback',
+        messagePlaceholder: 'Report an issue or share your ideas.',
+        // Allows for customizing the feedback form
+        ...pluginOptions.feedbackIntegration
+      })
+    )
+  }
 }

--- a/packages/gatsby-plugin-jaen/src/gatsby/types.ts
+++ b/packages/gatsby-plugin-jaen/src/gatsby/types.ts
@@ -1,4 +1,5 @@
 import {PluginOptions} from 'gatsby'
+import type {feedbackIntegration} from '@sentry/gatsby'
 
 export interface JaenPluginOptions extends PluginOptions {
   zitadel: {
@@ -11,4 +12,6 @@ export interface JaenPluginOptions extends PluginOptions {
   googleAnalytics?: {
     trackingIds?: string[]
   }
+
+  feedbackIntegration?: Parameters<typeof feedbackIntegration>[0]
 }


### PR DESCRIPTION
This pull request introduces changes to the `gatsby-plugin-jaen` package, focusing on the Sentry feedback integration. The changes allow for customizable feedback forms and include updates to the plugin options type definition.

### Sentry Feedback Integration:

* [`packages/gatsby-plugin-jaen/src/gatsby/on-client-entry.ts`](diffhunk://#diff-4a859af4c96f2e5ec71fc7e4560cd8dc19f4bf0fef213f912c597b26ae6d1657L38-R51): Re-enabled the Sentry feedback integration with a conditional check based on `pluginOptions.feedbackIntegration`. This allows for customization of the feedback form using the provided options.

### Type Definitions:

* [`packages/gatsby-plugin-jaen/src/gatsby/types.ts`](diffhunk://#diff-4f7521f6bd89cd568f1967a11e361494f0b9a34d194f7e3611805dbd3a73485eR2): Added an import for `feedbackIntegration` from `@sentry/gatsby` to support the new feedback integration options.
* [`packages/gatsby-plugin-jaen/src/gatsby/types.ts`](diffhunk://#diff-4f7521f6bd89cd568f1967a11e361494f0b9a34d194f7e3611805dbd3a73485eR15-R16): Extended the `JaenPluginOptions` interface to include an optional `feedbackIntegration` property, allowing users to pass parameters to customize the Sentry feedback form.