### PR TITLE
feat: add props to ChevronRight icon in DayPicker

### DIFF
--- a/packages/gatsby-plugin-jaen/src/components/ui/calendar.tsx
+++ b/packages/gatsby-plugin-jaen/src/components/ui/calendar.tsx
@@ -52,8 +52,8 @@ function Calendar({
         ...classNames
       }}
       components={{
-        IconLeft: ({...props}) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({...props}) => <ChevronRight className="h-4 w-4" />
+        IconLeft: ({...props}) => <ChevronLeft className="h-4 w-4" {...props} />,
+        IconRight: ({...props}) => <ChevronRight className="h-4 w-4" {...props} />
       }}
       {...props}
     />


### PR DESCRIPTION
There was a build error because the props weren't used.