### PR TITLE
feat: remove 'add' group from user menu

### DIFF
--- a/packages/gatsby-plugin-jaen/src/slices/jaen-frame.tsx
+++ b/packages/gatsby-plugin-jaen/src/slices/jaen-frame.tsx
@@ -87,23 +87,23 @@ const Slice: React.FC<SliceProps> = props => {
     const isJaenAdmin = checkUserRoles(auth.user, ['jaen:admin'])
 
     if (isJaenAdmin) {
-      extendMenu('user', {
-        group: 'add',
-        items: {
-          addPage: {
-            label: 'New page',
-            icon: FaSitemap,
-            path: `/cms/pages/new/#${btoa(props.jaenPageId)}`
-          },
-          addMedia: {
-            label: 'New media',
-            icon: FaImage,
-            onClick: () => {
-              mediaModal.toggleModal()
-            }
-          }
-        }
-      })
+      // extendMenu('user', {
+      //   group: 'add',
+      //   items: {
+      //     addPage: {
+      //       label: 'New page',
+      //       icon: FaSitemap,
+      //       path: `/cms/pages/new/#${btoa(props.jaenPageId)}`
+      //     },
+      //     addMedia: {
+      //       label: 'New media',
+      //       icon: FaImage,
+      //       onClick: () => {
+      //         mediaModal.toggleModal()
+      //       }
+      //     }
+      //   }
+      // })
 
       // Add jaenCMS user menu
       extendMenu('user', {


### PR DESCRIPTION
 - The jaen frame that contains the media browser is not working properly
 - New page is not really needed at the moment

This change could very well be temporary, but for now it is better to remove the 'add' group from the user menu.